### PR TITLE
Fix minor syntax errors in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
               << "\n";
   };
 
-  auto map_to_type = petra::make_string_map("dog"_s, "fish"_s, "cat"_s);
+  auto map_to_type = petra::make_string_map(callback, "dog"_s, "fish"_s, "cat"_s);
 
   map_to_type(input);
 }


### PR DESCRIPTION
This commit adds the missing callback argument in the last example.
*I was also fixing the missing brace in the second example but it looks like you already noticed it :)*